### PR TITLE
Fix `AddIiwa` and `AddWsg` imports

### DIFF
--- a/iiwa_setup/iiwa/hardware_station.py
+++ b/iiwa_setup/iiwa/hardware_station.py
@@ -5,10 +5,9 @@ from typing import List, Union
 
 import numpy as np
 
+from manipulation.scenarios import AddIiwa, AddWsg
 from manipulation.station import (
-    AddIiwa,
     AddPointClouds,
-    AddWsg,
     ConfigureParser,
     MakeHardwareStation,
     Scenario,


### PR DESCRIPTION
In the latest versions of the manipulation repo (including the version specified in pyproject.toml), `AddIiwa` and `AddWsg` have moved to `scenarios.py`. So they need to be imported from `manipulation.scenarios`.